### PR TITLE
Grammar Tree View UI V1

### DIFF
--- a/GBlasonWebApp/src/app/tree-view/TreeViewUINode.ts
+++ b/GBlasonWebApp/src/app/tree-view/TreeViewUINode.ts
@@ -122,16 +122,12 @@ export class TreeViewNodeSVG extends EventTarget {
       return;
     }
     if (expansion) {
-      this.renderer.setAttribute(this.expansionIcon, "d", this._expand_less_icon);
-      if (this.linksObject != null) {
-        this.renderer.setAttribute(this.linksObject, "class", "node-link");
-      }
+      if (this.expansionIcon != null) { this.renderer.setAttribute(this.expansionIcon, "d", this._expand_less_icon); }
+      if (this.linksObject != null) { this.renderer.setAttribute(this.linksObject, "class", "node-link"); }
     }
     else {
-      this.renderer.setAttribute(this.expansionIcon, "d", this._expand_more_icon);
-      if (this.linksObject != null) {
-        this.renderer.setAttribute(this.linksObject, "class", "node-link hidden");
-      }
+      if (this.expansionIcon != null) { this.renderer.setAttribute(this.expansionIcon, "d", this._expand_more_icon); }
+      if (this.linksObject != null) { this.renderer.setAttribute(this.linksObject, "class", "node-link hidden"); }
     }
   }
 

--- a/GBlasonWebApp/src/app/tree-view/tree-view.component.html
+++ b/GBlasonWebApp/src/app/tree-view/tree-view.component.html
@@ -1,12 +1,12 @@
 <mat-toolbar class="tree-toolbar">
   <button mat-icon-button class="toolbar-icon" aria-label="center button" (click)="onCenterClick()">
-    <mat-icon>center_focus_weak</mat-icon>
+    <mat-icon>filter_center_focus</mat-icon>
   </button>
-  <button mat-icon-button class="toolbar-icon" aria-label="center button" disabled>
-    <mat-icon>unfold_more_double</mat-icon>
+  <button mat-icon-button class="toolbar-icon" aria-label="center button" (click)="onExpandAllClick()">
+    <mat-icon>unfold_more</mat-icon>
   </button>
-  <button mat-icon-button class="toolbar-icon" aria-label="center button" disabled>
-    <mat-icon>unfold_less_double</mat-icon>
+  <button mat-icon-button class="toolbar-icon" aria-label="center button" (click)="onCollapseAllClick()">
+    <mat-icon>unfold_less</mat-icon>
   </button>
   <button mat-icon-button class="toolbar-icon" aria-label="center button" disabled>
     <mat-icon>fit_screen</mat-icon>

--- a/GBlasonWebApp/src/app/tree-view/tree-view.component.ts
+++ b/GBlasonWebApp/src/app/tree-view/tree-view.component.ts
@@ -122,6 +122,32 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
     console.log(`translated the canvas to (${this._offset.x},${this._offset.y})`);
   }
 
+  onExpandAllClick() {
+    //in this version we only expand the nodes that have already gotten their children
+
+    if (this.rootNodeUi == null || this.rootNodeUi.svgNode == null) {
+      return;
+    }
+    this.expandFrom(this.rootNodeUi);
+  }
+
+  private expandFrom(node: TreeViewUINode, expand: boolean = true) {
+    if (node == null || node.children.length == 0) {
+      return;
+    }
+    node.expand(expand);
+    for (var i = 0; i < node.children.length; i++) {
+      this.expandFrom(node.children[i], expand);
+    }
+  }
+
+  onCollapseAllClick() {
+    if (this.rootNodeUi == null || this.rootNodeUi.svgNode == null) {
+      return;
+    }
+    this.expandFrom(this.rootNodeUi, false);
+  }
+
   /**
    * Handle the click on the expand button in the node card.
    * @param event the event sent by the UI


### PR DESCRIPTION
### Support to collapse and expand all

- [x]  Change the icon to collapse all for a - icon (or multiple minuses?)
- [x]  Change the icon to expand for a + icon (or multiple pluses?)
- [x]  On collapse all, reduce all the tree so that only the head become visible
- [ ]  ~~On the expand all start to expand all nodes including requesting their children one at a time following a left first tree exploration algorythm until a leaf or a reference is found~~ (depending to the reference node support requirement to identify them server side)