### PR TITLE
Zoom and Fit to Screen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,23 +4,8 @@ version: 2.1
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
-jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
-    docker:
-      - image: cimg/base:stable
-    # Add steps to the job
-    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
-    steps:
-      - checkout
-      - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
+  
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
-workflows:
-  say-hello-workflow:
-    jobs:
-      - say-hello
+

--- a/GBlason.sln
+++ b/GBlason.sln
@@ -45,9 +45,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WebApp", "WebApp", "{F512CC
 EndProject
 Project("{54A90642-561A-4BB1-A94E-469ADEE60C69}") = "GBlasonWebApp", "GBlasonWebApp\GBlasonWebApp.esproj", "{4525B839-95F5-4649-8770-CDCABC772B2A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GBlasonWebAPI", "GBlasonWebAPI\GBlasonWebAPI.csproj", "{3264A8D5-3599-49F3-9959-5E2C9BE6DB28}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GBlasonWebAPI", "GBlasonWebAPI\GBlasonWebAPI.csproj", "{3264A8D5-3599-49F3-9959-5E2C9BE6DB28}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GBlason.WebApi.Test", "GBlason.WebApi.Test\GBlason.WebApi.Test.csproj", "{35C597B4-1846-443B-ABA2-71B33B92AEFA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GBlason.WebApi.Test", "GBlason.WebApi.Test\GBlason.WebApi.Test.csproj", "{35C597B4-1846-443B-ABA2-71B33B92AEFA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CD1BC637-993F-4B1F-BC7C-40C07ACADB22}"
+	ProjectSection(SolutionItems) = preProject
+		.circleci\config.yml = .circleci\config.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/GBlasonWebApp/src/app/app.module.ts
+++ b/GBlasonWebApp/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { BlasonParsingComponent } from './blason-parsing/blason-parsing.componen
 import { CoatOfArmEditorComponent } from './coat-of-arm-editor/coat-of-arm-editor.component';
 import { HttpErrorComponent } from './http-error/http-error.component';
 import { TreeViewComponent } from './tree-view/tree-view.component';
+import { ZoomViewComponent } from './zoom-view/zoom-view.component';
 
 
 @NgModule({
@@ -26,6 +27,7 @@ import { TreeViewComponent } from './tree-view/tree-view.component';
     CoatOfArmEditorComponent,
     HttpErrorComponent,
     TreeViewComponent,
+    ZoomViewComponent,
   ],
   imports: [
     BrowserModule, HttpClientModule,

--- a/GBlasonWebApp/src/app/ebnf/ebnf.component.css
+++ b/GBlasonWebApp/src/app/ebnf/ebnf.component.css
@@ -20,3 +20,9 @@
   flex-direction: column;
   align-items: center;
 }
+
+.zoom-tree-view {
+  max-width: 100vw;
+  display: flex;
+  flex-direction: column;
+}

--- a/GBlasonWebApp/src/app/ebnf/ebnf.component.html
+++ b/GBlasonWebApp/src/app/ebnf/ebnf.component.html
@@ -1,4 +1,4 @@
-<mat-tab-group mat-align-tabs="center">
+<mat-tab-group (selectedTabChange)="onTabChanged($event)" mat-align-tabs="center">
   <mat-tab label="Raw EBNF">
     <div *ngIf="requestRawInProgress">
       <mat-progress-bar mode="query"></mat-progress-bar>

--- a/GBlasonWebApp/src/app/ebnf/ebnf.component.ts
+++ b/GBlasonWebApp/src/app/ebnf/ebnf.component.ts
@@ -1,6 +1,7 @@
 import { DataSource } from '@angular/cdk/collections';
 import { HttpClient, HttpErrorResponse, HttpEvent, HttpParamsOptions, HttpRequest, HttpResponse } from '@angular/common/http';
 import { Component, ElementRef, OnInit } from '@angular/core';
+import { MatTab, MatTabChangeEvent } from '@angular/material/tabs';
 
 @Component({
   selector: 'app-ebnf',
@@ -9,7 +10,6 @@ import { Component, ElementRef, OnInit } from '@angular/core';
 })
 
 export class EbnfComponent implements OnInit {
-
   constructor(private http: HttpClient) { }
 
   rawEbnf: string = '';
@@ -19,11 +19,17 @@ export class EbnfComponent implements OnInit {
   requestRawInProgress = false;
   requestTreeInProgress = false;
 
+  currentTab: MatTab | null = null;
+
   treeEbnf: TreeViewNode | null = null;
 
   ngOnInit(): void {
     this.getRawEbnf();
     this.getTreeEbnf();
+  }
+
+  onTabChanged(event: MatTabChangeEvent) {
+    this.currentTab = event.tab
   }
 
   getTreeEbnf(id: string = ""): void {

--- a/GBlasonWebApp/src/app/tree-view/TreeViewUINode.ts
+++ b/GBlasonWebApp/src/app/tree-view/TreeViewUINode.ts
@@ -98,7 +98,7 @@ export class TreeViewNodeSVG extends EventTarget {
   //constants of the node UI
   private _node_width = 180;
   private _node_height = 132;
-  private _node_margin = 28;
+  readonly _node_margin = 28;
   private _node_roundAngle = 4;
   private _node_line_thickness_center_delta = 1; //half of the thickness rounded down
 

--- a/GBlasonWebApp/src/app/tree-view/tree-view.component.html
+++ b/GBlasonWebApp/src/app/tree-view/tree-view.component.html
@@ -8,7 +8,7 @@
   <button mat-icon-button class="toolbar-icon" aria-label="center button" (click)="onCollapseAllClick()">
     <mat-icon>unfold_less</mat-icon>
   </button>
-  <button mat-icon-button class="toolbar-icon" aria-label="center button" disabled>
+  <button mat-icon-button class="toolbar-icon" aria-label="center button" (click)="onZoomToFitClick()">
     <mat-icon>fit_screen</mat-icon>
   </button>
 </mat-toolbar>

--- a/GBlasonWebApp/src/app/tree-view/tree-view.component.html
+++ b/GBlasonWebApp/src/app/tree-view/tree-view.component.html
@@ -15,9 +15,9 @@
 <div class="canvas">
   <svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" class="svg-content"
     (pointerdown)="onStartDrag($event)" (pointermove)="onDrag($event)" (pointerup)="onStopDrag($event)"
-    (pointerleave)="onStopDrag($event)" #svg>
+    (pointerleave)="onStopDrag($event)" (wheel)="onWheel($event)" #svg>
 
-    <g #canvas transform="translate(0,0)"></g>
+    <g #canvas></g>
 
   </svg>
 </div>

--- a/GBlasonWebApp/src/app/tree-view/tree-view.component.scss
+++ b/GBlasonWebApp/src/app/tree-view/tree-view.component.scss
@@ -87,3 +87,12 @@
   fill-opacity: 0;
   pointer-events: all;
 }
+
+.cross-debug{
+  stroke-width: 1px;
+  stroke: red;
+}
+
+.invisible{
+  fill: none;
+}

--- a/GBlasonWebApp/src/app/tree-view/tree-view.component.ts
+++ b/GBlasonWebApp/src/app/tree-view/tree-view.component.ts
@@ -148,6 +148,23 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
     this.expandFrom(this.rootNodeUi, false);
   }
 
+  onZoomToFitClick() {
+    if (this.rootNodeUi == null || this.rootNodeUi.svgNode == null) {
+      return;
+    }
+    //finding out what is the current size of the canvas
+    var canvasInfo = this.canvasDom?.nativeElement.getBoundingClientRect();
+    //finding out what is the current container size
+    var svgInfo = this.svgDom?.nativeElement.getBoundingClientRect();
+
+    //I just need to set the svg viewbox to the height and width of the canvasdom element
+    //only when the size of the canvasDom in absolute unit is bigger (either height or width) than the svg
+    //so the svg size is the minimum
+    //and with a predefined maximum width based on how small it gets from pratical experience
+
+    var ratioWidth = svgInfo.width / canvasInfo.width;
+    var ratioHeight = svgInfo.height / canvasInfo.height;
+  }
   /**
    * Handle the click on the expand button in the node card.
    * @param event the event sent by the UI

--- a/GBlasonWebApp/src/app/tree-view/tree-view.component.ts
+++ b/GBlasonWebApp/src/app/tree-view/tree-view.component.ts
@@ -41,10 +41,15 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
   private _xCounter: number = 0;
 
   private _startDragPoint: Point = { x: 0, y: 0 };
-  private _offset: Point = { x: 0, y: 0 };
   private _dragStarted: boolean = false;
 
+  private _top_left_anchor: boolean = false;
+
+  private _zoomScale: number = 100;
+  private _zoomRoundingAccuracy = 4;
+
   private _canvasMatrix = [1, 0, 0, 1, 0, 0];
+  private readonly _defaultMatrix = [1, 0, 0, 1, 0, 0];
 
   //#region event handlers
 
@@ -98,8 +103,19 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
       return;
     }
     //we try to zoom out or in depending on the event
-    var delta = event.wheelDelta;
-    this.zoomFactor(delta);
+    var delta = event.wheelDelta > 0 ? 10 : -10;
+
+    //not optimum ideally should be calculed once, and then on resize, but no performance issues at that stage
+    var svgLocation = this.svgDom?.nativeElement.getBoundingClientRect();
+    var canvasLocation = this.canvasDom?.nativeElement.getBoundingClientRect();
+
+    var canvasTopLeft: Point = { x: canvasLocation.top - svgLocation.top, y: canvasLocation.left - svgLocation.left };
+    console.log(`tree-view-component.onWheel => canvas top left: (${canvasTopLeft.x}, ${canvasTopLeft.y})`);
+
+    //trying at the center
+    var centerPoint = { x: event.clientX - canvasLocation.left, y: event.clientY - canvasLocation.top };
+
+    this.zoom(delta, centerPoint);
   }
 
   /**
@@ -176,6 +192,46 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
 
   //#endregion
 
+  //#region matrix and math methods on the tree
+
+  /**
+   * Calculates the x axis positions for all the nodes in the tree
+   */
+  calculateXPositions(): void {
+    //we need to go through the tree, for all leaves we add the x value in the counter and increase it by 1
+    //at the end of this the direct parent get a value which is the average of the children
+    if (this.treeHead == null) {
+      return;
+    }
+    this._xCounter = 0;
+    this.calculateXPositionsStep(this.rootNodeUi);
+  }
+
+  /**
+   * Calculates the index of all the nodes on the x axis, the leaves takes all one x natural value each, their parents are the average of their children's positions
+   * This is used later to calculate the position of each node and avoid them touching or overlapping each other
+   * @param node the node from which to calculate (the head of the tree)
+   * @returns nothing, when the node xposition value has been set
+   */
+  calculateXPositionsStep(node: TreeViewUINode | null) {
+    if (node == null) {
+      return;
+    }
+    if ((node.children?.length ?? 1) == 0) {
+      node.isLeaf = true;
+      node.xPosition = this._xCounter++;
+    }
+    else {
+      var parentX = 0;
+      for (var i = 0; i < node.children.length; i++) {
+        var child = node.children[i];
+        this.calculateXPositionsStep(child);
+        parentX += child.xPosition;
+      }
+      node.xPosition = parentX / node.children.length;
+    }
+  }
+
   centerToNode(node: TreeViewUINode) {
 
     if (node.svgNode == null) {
@@ -192,7 +248,7 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
 
     var targetPosition: Point = {
       x: currentSvgSize.width / 2 - currentNodeSize.width / 2,
-      y: node.svgNode._node_margin //we could add a small padding for the sake of UI comfort rather than 0 ...
+      y: Math.max(node.svgNode._node_margin * this._zoomScale / 100, node.svgNode._node_margin)
     };
 
     var log = `tree-view-component.centerToNode(node: ${node.treeNode.RealElement?.Name})`;
@@ -204,6 +260,90 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
     //we pass the difference in location to the pan to move the node within the expected position
     this.pan(targetPosition.x - currentNodeLocation.e, targetPosition.y - currentNodeLocation.f);
   }
+
+  /**
+   * Pans the SVG canvas to the direction given by the dx and dy
+   * @param dx the distance to move on the x axis
+   * @param dy the distance to move on the y axis
+   */
+  private pan(dx: number, dy: number) {
+    this._canvasMatrix[4] += dx;
+    this._canvasMatrix[5] += dy;
+
+    var newMatrix = `matrix(${this._canvasMatrix.join(' ')})`;
+    this.renderer.setAttribute(this.canvasDom?.nativeElement, "transform", newMatrix);
+    var log = `tree-view-component.pan(dx: ${dx}, dy: (${dy}))`;
+    log += `\n\t> final ${newMatrix}`;
+    console.log(log);
+  }
+
+  private roundNum(num: number, length: number) {
+    var number = Math.round(num * Math.pow(10, length)) / Math.pow(10, length);
+    return number;
+  }
+
+  /**
+   * Zooms the SVG by the given scale as a step in percentage of zoom direction, like +10 (=+10% zoom in) or -25 (=25% zoom out)
+   * @param scale the percentage by which to zoom in or out
+   * @param zoomCenter the center point from which to perform the zooming update
+   */
+  private zoom(scale: number, zoomCenter: Point) {
+    var totalPercentDelta = this._zoomScale + scale;
+    if (totalPercentDelta <= 10 || totalPercentDelta > 200) {
+      return;
+    }
+
+    //information available from our perspective
+    //The percentage increase step (scale)
+    //The total percentage increase from the origin (totalPercentDelta = this._zoomScale + scale)
+    //The previous percentage increase before the current step (this._zoomScale)
+    //The position of the cursor representing the zoom center within the reference of the canvas (zoomCenter)
+
+    var log = `tree-view-component.zoom(scale: ${scale}, zoomCenter: (${zoomCenter.x}, ${zoomCenter.y})) for a total zoom of ${totalPercentDelta}`;
+
+    //information to calculate
+    //the zoom transformation we apply to the canvas will grow or shrink the canvas, and all the points in it on the 2D axis
+    //we need to calculate the new position of the x and y point of the zoom center AFTER the zoom is applied
+    //the distance on BOTH axis will be affected by the ratio of totalPercentDelta/ this._zoomScale
+    var zoomChangeRatio = this.roundNum(totalPercentDelta / this._zoomScale, this._zoomRoundingAccuracy);
+    log += `\n\t> the current ratio of transformation is: ${zoomChangeRatio}`;
+    var newCenterX = this.roundNum(zoomChangeRatio * zoomCenter.x, this._zoomRoundingAccuracy);
+    var newCenterY = this.roundNum(zoomChangeRatio * zoomCenter.y, this._zoomRoundingAccuracy);
+    log += `\n\t> the new expected location of the point centered on the cursor will be : (${newCenterX}, ${newCenterY})`;
+    //Now that we know the future location of the zoom center point, we just need to correct the transformation to move it by as many pixels as the delta of the new and old location
+    var transformXCorrection = newCenterX - zoomCenter.x;
+    var transformYCorrection = newCenterY - zoomCenter.y;
+    log += `\n\t> corresponding to a translate correction of : (${-transformXCorrection}, ${-transformYCorrection})`;
+
+    //canvas matrix has 6 values noted from a to f matching an array [0-6]
+    //[0] = a = previous coordinate system X axis factor to apply to new X value
+    //[1] = b = previous coordinate system x axis factor to apply to new y value (always 0 in 2D)
+    //[2] = c = previous coordinate system y axis factor to apply to new x value (always 0 in 2D)
+    //[3] = d = previous coordinate system y axis factor to apply to new y value
+    //[4] = e = direct x translation (the correction to keep the zoom centered on the cursor)
+    //[5] = f = direct y translation (the correction to keep the zoom centered on the cursor)
+
+    //of course we also need to apply the new total zoom from the origin factor to the zoom matrix
+    //example if we are now at 120% we multiply the original value by 120/100 --> 1.2 (so 1 --> 1.2)
+
+    for (var i = 0; i < 4; i++) {
+      this._canvasMatrix[i] = this._defaultMatrix[i] * (totalPercentDelta / 100);
+    }
+
+    this._canvasMatrix[4] -= transformXCorrection;
+    this._canvasMatrix[5] -= transformYCorrection;
+
+    this._zoomScale = totalPercentDelta;
+
+    var newMatrix = `matrix(${this._canvasMatrix.join(' ')})`;
+    log += `\n\t> final ${newMatrix}`;
+    this.renderer.setAttribute(this.canvasDom?.nativeElement, "transform", newMatrix);
+    console.log(log);
+  }
+
+  //#endregion
+
+  //#region tree manipulation / data retrieval
 
   getMoreNode(head: TreeViewUINode) {
     var httpRequest = new HttpRequest("GET", "api/ebnf/tree?head=" + head.treeNode.ElementId, { responseType: "text" });
@@ -232,45 +372,6 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
     });
   }
 
-  /**
-   * Pans the SVG canvas to the direction given by the dx and dy
-   * @param dx the distance to move on the x axis
-   * @param dy the distance to move on the y axis
-   */
-  private pan(dx: number, dy: number) {
-    this._canvasMatrix[4] += dx;
-    this._canvasMatrix[5] += dy;
-
-    this._offset.x += dx;
-    this._offset.y += dy;
-
-    var newMatrix = `matrix(${this._canvasMatrix.join(' ')})`;
-    this.renderer.setAttribute(this.canvasDom?.nativeElement, "transform", newMatrix);
-  }
-
-  /**
-   * Zooms factor
-   * @param factor
-   */
-  private zoomFactor(factor: number) {
-    console.log(`tree-view-component.zoomFactor(factor: ${factor})`);
-  }
-
-
-
-  /**
-   * Calculates the x axis positions for all the nodes in the tree
-   */
-  calculateXPositions(): void {
-    //we need to go through the tree, for all leaves we add the x value in the counter and increase it by 1
-    //at the end of this the direct parent get a value which is the average of the children
-    if (this.treeHead == null) {
-      return;
-    }
-    this._xCounter = 0;
-    this.calculateXPositionsStep(this.rootNodeUi);
-  }
-
   private expandFrom(node: TreeViewUINode, expand: boolean = true) {
     if (node == null || node.children.length == 0) {
       return;
@@ -278,46 +379,6 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
     node.expand(expand);
     for (var i = 0; i < node.children.length; i++) {
       this.expandFrom(node.children[i], expand);
-    }
-  }
-
-  /**
-   * Calculates the index of all the nodes on the x axis, the leaves takes all one x natural value each, their parents are the average of their children's positions
-   * This is used later to calculate the position of each node and avoid them touching or overlapping each other
-   * @param node the node from which to calculate (the head of the tree)
-   * @returns nothing, when the node xposition value has been set
-   */
-  calculateXPositionsStep(node: TreeViewUINode | null) {
-    if (node == null) {
-      return;
-    }
-    if ((node.children?.length ?? 1) == 0) {
-      node.isLeaf = true;
-      node.xPosition = this._xCounter++;
-    }
-    else {
-      var parentX = 0;
-      for (var i = 0; i < node.children.length; i++) {
-        var child = node.children[i];
-        this.calculateXPositionsStep(child);
-        parentX += child.xPosition;
-      }
-      node.xPosition = parentX / node.children.length;
-    }
-  }
-
-  /**
-   * Refresh the whole UI by calculating the new UI tree with all nodes, recalculating their position, adding the new nodes and transforming the actual SVG nodes positions
-   * @param parent the parent from which the update needs to happen (the rendering is always from the first root)
-   * @param children the new nodes that needs to be added (rendered) into the tree
-   */
-  updateUi(parent: TreeViewUINode | null, children: TreeViewNode[]): void {
-    var newHeads = this.buildUiTree(parent, children);
-    this.calculateXPositions();
-    if (this.rootNodeUi != null) {
-      console.log(`tree-view-component.updateUi(parent: ${parent?.treeNode.RealElement?.Name}, children: [${children.length}])`);
-      this.renderTree(null, [this.rootNodeUi]);
-      var canvasInfo = this.canvasDom?.nativeElement.getBoundingClientRect();
     }
   }
 
@@ -352,6 +413,25 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
     return nodeUi;
   }
 
+  //#endregion
+
+  //#region Rendering methods
+
+  /**
+   * Refresh the whole UI by calculating the new UI tree with all nodes, recalculating their position, adding the new nodes and transforming the actual SVG nodes positions
+   * @param parent the parent from which the update needs to happen (the rendering is always from the first root)
+   * @param children the new nodes that needs to be added (rendered) into the tree
+   */
+  updateUi(parent: TreeViewUINode | null, children: TreeViewNode[]): void {
+    var newHeads = this.buildUiTree(parent, children);
+    this.calculateXPositions();
+    if (this.rootNodeUi != null) {
+      console.log(`tree-view-component.updateUi(parent: ${parent?.treeNode.RealElement?.Name}, children: [${children.length}])`);
+      this.renderTree(null, [this.rootNodeUi]);
+      var canvasInfo = this.canvasDom?.nativeElement.getBoundingClientRect();
+    }
+  }
+
   /**
    * Renders the tree by creating new nodes and transforming all the nodes to their new position
    * @param parent
@@ -362,6 +442,21 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
     if (node === null || node.length === 0 || this._renderingReady === false || this._dataReady === false) {
       return;
     }
+
+    if(!this._top_left_anchor)
+    {
+      //we had a 1*1 rect pixel without transformation within the group to make SURE that the 0,0 reference frame for the matrix transform
+      //is indeed the top left corner of our canvas, if not, then the actual topmost, leftmost object (dynamic) is our reference point
+      //which make the maths overly complicated for no reason
+      var anchor = this.renderer.createElement("rect", "svg");
+      this.renderer.setAttribute(anchor, "width", "1");
+      this.renderer.setAttribute(anchor, "height", "1");
+      this.renderer.setAttribute(anchor, "class", "invisible");
+      this.renderer.appendChild(this.canvasDom?.nativeElement, anchor);
+      this._top_left_anchor = true;
+    }
+
+
     var log = `tree-view-component.renderTree(parent: ${parent?.treeNode.RealElement?.Name}, node[]:{${node[0].treeNode.RealElement?.Name}`;
     for (var i = 1; i < node.length; i++) {
       log += ", " + node[i].treeNode.RealElement?.Name;
@@ -377,6 +472,27 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
         console.log(`tree-view-component.renderTree.addEventListener(node: ${node[i].treeNode.RealElement?.Name})`);
         renderedNode.addEventListener("expandButtonClick", this.onNodeExpandClick.bind(this, node[i]));
         this.renderer.appendChild(this.canvasDom?.nativeElement, renderedNode.domObject);
+
+        // if (this._crossDebugZoomg == null) {
+        //   this._crossDebugZoomg = this.renderer.createElement("g", "svg");
+        //   var crossDebugZoomh = this.renderer.createElement("line", "svg");
+        //   var crossDebugZoomv = this.renderer.createElement("line", "svg");
+        //   //center of the debug cross should be
+        //   var centerDebug: Point = { x: 164, y: 62 };
+        //   this.renderer.setAttribute(crossDebugZoomh, "x1", (centerDebug.x - 20).toString());
+        //   this.renderer.setAttribute(crossDebugZoomh, "y1", (centerDebug.y).toString());
+        //   this.renderer.setAttribute(crossDebugZoomh, "x2", (centerDebug.x + 20).toString());
+        //   this.renderer.setAttribute(crossDebugZoomh, "y2", (centerDebug.y).toString());
+        //   this.renderer.setAttribute(crossDebugZoomv, "x1", (centerDebug.x).toString());
+        //   this.renderer.setAttribute(crossDebugZoomv, "y1", (centerDebug.y - 20).toString());
+        //   this.renderer.setAttribute(crossDebugZoomv, "x2", (centerDebug.x).toString());
+        //   this.renderer.setAttribute(crossDebugZoomv, "y2", (centerDebug.y + 20).toString());
+        //   this.renderer.setAttribute(crossDebugZoomv, "class", "cross-debug");
+        //   this.renderer.setAttribute(crossDebugZoomh, "class", "cross-debug");
+        //   this.renderer.appendChild(this.svgDom?.nativeElement, this._crossDebugZoomg);
+        //   this.renderer.appendChild(this._crossDebugZoomg, crossDebugZoomh);
+        //   this.renderer.appendChild(this._crossDebugZoomg, crossDebugZoomv);
+        // }
       }
     }
     //and execute the same for the child of the current node and after the children are created we do the parent links
@@ -394,4 +510,6 @@ export class TreeViewComponent implements OnInit, AfterViewInit, OnChanges {
       }
     }
   }
+
+  //#endregion
 }

--- a/GBlasonWebApp/src/app/zoom-view/zoom-view.component.html
+++ b/GBlasonWebApp/src/app/zoom-view/zoom-view.component.html
@@ -1,0 +1,9 @@
+<div class="canvas">
+  <svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" class="svg-content"
+    (pointerdown)="onStartDrag($event)" (pointermove)="onDrag($event)" (pointerup)="onStopDrag($event)"
+    (pointerleave)="onStopDrag($event)" (wheel)="onWheel($event)" #svg>
+
+    <g #canvas class="svg-canvas"></g>
+
+  </svg>
+</div>

--- a/GBlasonWebApp/src/app/zoom-view/zoom-view.component.scss
+++ b/GBlasonWebApp/src/app/zoom-view/zoom-view.component.scss
@@ -1,0 +1,36 @@
+.svg-canvas{
+  fill: rgba($color: #fff, $alpha: 0.15);
+}
+
+.canvas {
+  position: absolute;
+  bottom: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+}
+
+.node-text {
+  fill: #fff;
+  font: 400 10px/16px Roboto, "Helvetica Neue", sans-serif;
+
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.svg-content {
+  width: 100%;
+  height: 100%;
+}
+
+.cross-debug{
+  stroke-width: 1px;
+  stroke: red;
+}
+
+.invisible{
+  fill: none;
+}
+

--- a/GBlasonWebApp/src/app/zoom-view/zoom-view.component.spec.ts
+++ b/GBlasonWebApp/src/app/zoom-view/zoom-view.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ZoomViewComponent } from './zoom-view.component';
+
+describe('ZoomViewComponent', () => {
+  let component: ZoomViewComponent;
+  let fixture: ComponentFixture<ZoomViewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ZoomViewComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ZoomViewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/GBlasonWebApp/src/app/zoom-view/zoom-view.component.ts
+++ b/GBlasonWebApp/src/app/zoom-view/zoom-view.component.ts
@@ -1,0 +1,312 @@
+import { AfterViewInit, Component, Renderer2, ElementRef, Input, OnInit, ViewChild, OnChanges, SimpleChanges } from '@angular/core';
+import { Point } from '../tree-view/TreeViewUINode';
+
+@Component({
+  selector: 'app-zoom-view',
+  templateUrl: './zoom-view.component.html',
+  styleUrls: ['./zoom-view.component.scss']
+})
+
+export class ZoomViewComponent implements OnInit, AfterViewInit, OnChanges {
+
+  constructor(private renderer: Renderer2) { }
+
+  ngAfterViewInit(): void {
+  }
+
+  /**
+   * View child of tree view component
+   * canvas is the parent div container of the whole tree used to add the root(s) and to fill the display area
+   * svg is the parent svg container of the whole tree, used to move the tree as one element
+   */
+  @ViewChild('canvas')
+  canvasDom: ElementRef | null = null;
+  @ViewChild('svg')
+  svgDom: ElementRef | null = null;
+
+  @Input("isActive")
+  isActive: boolean = false;
+
+  canvasCoordinateText: any;
+  canvasObject: any;
+  objectCoordinateText: any;
+  objectCoordinateAbsText: any;
+  cursCoordinateLocText: any;
+  cursCoordinateAbsText: any;
+
+  private _startDragPoint: Point = { x: 0, y: 0 };
+  private _dragStarted: boolean = false;
+
+  private _crossDebugZoomg: any = null;
+  private _centerDebugPoint: Point = { x: 150, y: 150 };
+
+  private _zoomScale: number = 100;
+  private _zoomRoundingAccuracy = 4;
+
+  private _canvasMatrix = [1, 0, 0, 1, 0, 0];
+  private readonly _defaultMatrix = [1, 0, 0, 1, 0, 0];
+
+  private uiCreated: boolean = false;
+
+  //#region event handlers
+
+  ngOnInit(): void {
+
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes["isActive"] !== null) {
+      if (changes["isActive"].currentValue === true)
+        this.UiCreate();
+    }
+  }
+
+  UiCreate(): void {
+    if (this.uiCreated) {
+      return;
+    }
+    this.uiCreated = true;
+    //rendering the objects
+    //background for the canvas (css style is enough)
+    //the canvas coordinates on the top left (and init at 100,100)
+
+    var canvasRect = this.renderer.createElement("rect", "svg");
+    this.renderer.setAttribute(canvasRect, "width", "300");
+    this.renderer.setAttribute(canvasRect, "height", "300");
+    this.renderer.setAttribute(canvasRect, "class", "invisible");
+    this.renderer.appendChild(this.canvasDom?.nativeElement, canvasRect);
+    var canvasCoordinate = this.renderer.createElement("foreignObject", "svg");
+    this.renderer.setAttribute(canvasCoordinate, "width", "200");
+    this.renderer.setAttribute(canvasCoordinate, "height", "16");
+    this.renderer.setAttribute(canvasCoordinate, "transform", "translate(20,20)");
+    var canvasCoordinateTextDiv = this.renderer.createElement("div");
+    this.renderer.appendChild(canvasCoordinate, canvasCoordinateTextDiv);
+    this.renderer.setAttribute(canvasCoordinateTextDiv, "class", "node-text");
+    this.canvasCoordinateText = this.renderer.createText("0,0");
+    this.renderer.appendChild(canvasCoordinateTextDiv, this.canvasCoordinateText);
+
+    //the main object in the canvas (init at 100,100 within the canvas itself)
+    this.canvasObject = this.renderer.createElement("rect", "svg");
+    this.renderer.setAttribute(this.canvasObject, "width", "100");
+    this.renderer.setAttribute(this.canvasObject, "height", "100");
+    this.renderer.setAttribute(this.canvasObject, "transform", "translate(100,100)");
+    this.renderer.appendChild(this.canvasDom?.nativeElement, this.canvasObject);
+    this.renderer.appendChild(this.canvasDom?.nativeElement, canvasCoordinate);
+    //the main object coordinates in the canvas reference
+    var objectCoordinate = this.renderer.createElement("foreignObject", "svg");
+    this.renderer.setAttribute(objectCoordinate, "width", "100");
+    this.renderer.setAttribute(objectCoordinate, "height", "32");
+    this.renderer.setAttribute(objectCoordinate, "class", "node-text");
+    this.renderer.setAttribute(objectCoordinate, "transform", "translate(100,100)");
+    var objectCoordinateTextCanvas = this.renderer.createElement("div");
+    this.objectCoordinateText = this.renderer.createText("loc: 100,100");
+    var objectCoordinateTextCanvasAbs = this.renderer.createElement("div");
+    this.objectCoordinateAbsText = this.renderer.createText("abs: 100,100");
+    this.renderer.appendChild(objectCoordinate, objectCoordinateTextCanvas);
+    this.renderer.appendChild(objectCoordinate, objectCoordinateTextCanvasAbs);
+    this.renderer.appendChild(objectCoordinateTextCanvas, this.objectCoordinateText);
+    this.renderer.appendChild(objectCoordinateTextCanvasAbs, this.objectCoordinateAbsText);
+    this.renderer.appendChild(this.canvasDom?.nativeElement, objectCoordinate);
+
+    //the debug cross
+    this._crossDebugZoomg = this.renderer.createElement("g", "svg");
+    var crossDebugZoomh = this.renderer.createElement("line", "svg");
+    var crossDebugZoomv = this.renderer.createElement("line", "svg");
+    //center of the debug cross should be
+    this.renderer.setAttribute(crossDebugZoomh, "x1", (this._centerDebugPoint.x - 20).toString());
+    this.renderer.setAttribute(crossDebugZoomh, "y1", (this._centerDebugPoint.y).toString());
+    this.renderer.setAttribute(crossDebugZoomh, "x2", (this._centerDebugPoint.x + 20).toString());
+    this.renderer.setAttribute(crossDebugZoomh, "y2", (this._centerDebugPoint.y).toString());
+    this.renderer.setAttribute(crossDebugZoomv, "x1", (this._centerDebugPoint.x).toString());
+    this.renderer.setAttribute(crossDebugZoomv, "y1", (this._centerDebugPoint.y - 20).toString());
+    this.renderer.setAttribute(crossDebugZoomv, "x2", (this._centerDebugPoint.x).toString());
+    this.renderer.setAttribute(crossDebugZoomv, "y2", (this._centerDebugPoint.y + 20).toString());
+    this.renderer.setAttribute(crossDebugZoomv, "class", "cross-debug");
+    this.renderer.setAttribute(crossDebugZoomh, "class", "cross-debug");
+    this.renderer.appendChild(this.canvasDom?.nativeElement, this._crossDebugZoomg);
+    this.renderer.appendChild(this._crossDebugZoomg, crossDebugZoomh);
+    this.renderer.appendChild(this._crossDebugZoomg, crossDebugZoomv);
+
+    //the cursor for test where the zoom coordinates are piloted
+    var cursCoordinate = this.renderer.createElement("foreignObject", "svg");
+    this.renderer.setAttribute(cursCoordinate, "width", "100");
+    this.renderer.setAttribute(cursCoordinate, "height", "32");
+    this.renderer.setAttribute(cursCoordinate, "class", "node-text");
+    this.renderer.setAttribute(cursCoordinate, "transform", `translate(${this._centerDebugPoint.x},${this._centerDebugPoint.y})`);
+
+    var cursCoordinateText = this.renderer.createElement("div");
+    var cursCoordinateTextAbs = this.renderer.createElement("div");
+    this.cursCoordinateLocText = this.renderer.createText("loc: 100,100");
+    this.cursCoordinateAbsText = this.renderer.createText(`abs: ${this._centerDebugPoint.x},${this._centerDebugPoint.y}`);
+    this.renderer.appendChild(cursCoordinate, cursCoordinateText);
+    this.renderer.appendChild(cursCoordinate, cursCoordinateTextAbs);
+    this.renderer.appendChild(cursCoordinateText, this.cursCoordinateLocText);
+    this.renderer.appendChild(cursCoordinateTextAbs, this.cursCoordinateAbsText);
+    this.renderer.appendChild(this.canvasDom?.nativeElement, cursCoordinate);
+
+    this.UiLocationUpdate();
+  }
+
+  UiLocationUpdate() {
+    //updating the text of all the location based on the new location of all the elements
+    // canvasCoordinateText: any;
+    // objectCoordinateText: any;
+    // objectCoordinateAbsText: any;
+    // cursCoordinateLocText: any;
+    // cursCoordinateAbsText: any;
+    var canvasRect = this.canvasDom?.nativeElement.getBoundingClientRect();
+    var svgRect = this.svgDom?.nativeElement.getBoundingClientRect();
+
+    var canvasRectLocX = this.roundNum(canvasRect.left - svgRect.left, this._zoomRoundingAccuracy);
+    var canvasRectLocY = this.roundNum(canvasRect.top - svgRect.top, this._zoomRoundingAccuracy);
+
+    this.renderer.setValue(this.canvasCoordinateText, `${canvasRectLocX},${canvasRectLocY}`);
+
+    var canvasObjectRect = this.canvasObject.getBoundingClientRect();
+
+    var objLocX = this.roundNum(canvasObjectRect.left - canvasRect.left, this._zoomRoundingAccuracy);
+    var objLocY = this.roundNum(canvasObjectRect.top - canvasRect.top, this._zoomRoundingAccuracy);
+    var objAbsX = this.roundNum(canvasObjectRect.left - svgRect.left, this._zoomRoundingAccuracy);
+    var objAbsY = this.roundNum(canvasObjectRect.top - svgRect.top, this._zoomRoundingAccuracy);
+
+    this.renderer.setValue(this.objectCoordinateText, `loc: ${objLocX},${objLocY}`);
+    this.renderer.setValue(this.objectCoordinateAbsText, `abs: ${objAbsX},${objAbsY}`);
+
+    var cursAbsX = this.roundNum(this._centerDebugPoint.x + canvasRectLocX, this._zoomRoundingAccuracy);
+    var cursAbsY = this.roundNum(this._centerDebugPoint.y + canvasRectLocY, this._zoomRoundingAccuracy);
+    this.renderer.setValue(this.cursCoordinateAbsText, `abs: ${cursAbsX},${cursAbsY}`);
+
+  }
+
+  onStartDrag(event: PointerEvent) {
+    if (event == null) {
+      return;
+    }
+    this._startDragPoint = { x: event.clientX, y: event.clientY };
+    this._dragStarted = true;
+  }
+
+  onDrag(event: any) {
+    if (event == null || !this._dragStarted) {
+      return;
+    }
+    event.preventDefault();
+
+    //we calculate the difference of the current position vs the last position and pan by that much
+    this.pan(event.clientX - this._startDragPoint.x, event.clientY - this._startDragPoint.y);
+    //refresh the start position to the last event (this one)
+    this._startDragPoint = { x: event.clientX, y: event.clientY };
+  }
+
+  onStopDrag(event: any) {
+    //the new general position of the frame is the final offset
+    if (!this._dragStarted) {
+      return;
+    }
+    this._dragStarted = false;
+  }
+
+  onWheel(event: any) {
+    if (event == null) {
+      return;
+    }
+    //we try to zoom out or in depending on the event
+    var delta = event.wheelDelta > 0 ? 10 : -10;
+
+    //not optimum ideally should be calculed once, and then on resize, but no performance issues at that stage
+    var svgLocation = this.svgDom?.nativeElement.getBoundingClientRect();
+    var canvasLocation = this.canvasDom?.nativeElement.getBoundingClientRect();
+
+    var canvasTopLeft: Point = { x: canvasLocation.top - svgLocation.top, y: canvasLocation.left - svgLocation.left };
+
+    //trying at the center
+    var centerPoint = { x: event.clientX - canvasLocation.left, y: event.clientY - canvasLocation.top };
+    console.log(`zoom-view-component.onWheel => canvas top left: (${canvasTopLeft.x}, ${canvasTopLeft.y})`);
+
+    this.zoom(delta, centerPoint);
+  }
+  //#endregion
+
+  //#region matrix and math methods on the tree
+
+  /**
+   * Pans the SVG canvas to the direction given by the dx and dy
+   * @param dx the distance to move on the x axis
+   * @param dy the distance to move on the y axis
+   */
+  private pan(dx: number, dy: number) {
+    this._canvasMatrix[4] += dx;
+    this._canvasMatrix[5] += dy;
+
+    var newMatrix = `matrix(${this._canvasMatrix.join(' ')})`;
+    this.renderer.setAttribute(this.canvasDom?.nativeElement, "transform", newMatrix);
+    this.UiLocationUpdate();
+  }
+
+  private roundNum(num: number, length: number) {
+    var number = Math.round(num * Math.pow(10, length)) / Math.pow(10, length);
+    return number;
+  }
+
+  /**
+   * Zooms the SVG by the given scale as a step in percentage of zoom direction, like +10 (=+10% zoom in) or -25 (=25% zoom out)
+   * @param scale the percentage by which to zoom in or out
+   * @param zoomCenter the center point from which to perform the zooming update
+   */
+  private zoom(scale: number, zoomCenter: Point) {
+    var totalPercentDelta = this._zoomScale + scale;
+    if (totalPercentDelta <= 10 || totalPercentDelta > 200) {
+      return;
+    }
+
+    //information available from our perspective
+    //The percentage increase step (scale)
+    //The total percentage increase from the origin (totalPercentDelta = this._zoomScale + scale)
+    //The previous percentage increase before the current step (this._zoomScale)
+    //The position of the cursor representing the zoom center within the reference of the canvas (zoomCenter)
+
+    var log = `tree-view-component.zoom(scale: ${scale}, zoomCenter: (${zoomCenter.x}, ${zoomCenter.y})) for a total zoom of ${totalPercentDelta}`;
+
+    //information to calculate
+    //the zoom transformation we apply to the canvas will grow or shrink the canvas, and all the points in it on the 2D axis
+    //we need to calculate the new position of the x and y point of the zoom center AFTER the zoom is applied
+    //the distance on BOTH axis will be affected by the ratio of totalPercentDelta/ this._zoomScale
+    var zoomChangeRatio = this.roundNum(totalPercentDelta / this._zoomScale, this._zoomRoundingAccuracy);
+    log += `\n\t> the current ratio of transformation is: ${zoomChangeRatio}`;
+    var newCenterX = this.roundNum(zoomChangeRatio * zoomCenter.x, this._zoomRoundingAccuracy);
+    var newCenterY = this.roundNum(zoomChangeRatio * zoomCenter.y, this._zoomRoundingAccuracy);
+    log += `\n\t> the new expected location of the point centered on the cursor will be : (${newCenterX}, ${newCenterY})`;
+    //Now that we know the future location of the zoom center point, we just need to correct the transformation to move it by as many pixels as the delta of the new and old location
+    var transformXCorrection = this.roundNum(newCenterX - zoomCenter.x, this._zoomRoundingAccuracy);
+    var transformYCorrection = this.roundNum(newCenterY - zoomCenter.y, this._zoomRoundingAccuracy);
+    log += `\n\t> corresponding to a translate correction of : (${-transformXCorrection}, ${-transformYCorrection})`;
+
+    //canvas matrix has 6 values noted from a to f matching an array [0-6]
+    //[0] = a = previous coordinate system X axis factor to apply to new X value
+    //[1] = b = previous coordinate system x axis factor to apply to new y value (always 0 in 2D)
+    //[2] = c = previous coordinate system y axis factor to apply to new x value (always 0 in 2D)
+    //[3] = d = previous coordinate system y axis factor to apply to new y value
+    //[4] = e = direct x translation (the correction to keep the zoom centered on the cursor)
+    //[5] = f = direct y translation (the correction to keep the zoom centered on the cursor)
+
+    //of course we also need to apply the new total zoom from the origin factor to the zoom matrix
+    //example if we are now at 120% we multiply the original value by 120/100 --> 1.2 (so 1 --> 1.2)
+
+    for (var i = 0; i < 4; i++) {
+      this._canvasMatrix[i] = this._defaultMatrix[i] * (totalPercentDelta / 100);
+    }
+
+    this._canvasMatrix[4] -= transformXCorrection;
+    this._canvasMatrix[5] -= transformYCorrection;
+
+    this._zoomScale = totalPercentDelta;
+
+    var newMatrix = `matrix(${this._canvasMatrix.join(' ')})`;
+    log += `\n\t> final ${newMatrix}`;
+    this.renderer.setAttribute(this.canvasDom?.nativeElement, "transform", newMatrix);
+    console.log(log);
+    this.UiLocationUpdate();
+  }
+
+  //#endregion
+}


### PR DESCRIPTION
### Support for Zoom and fit to screen

- [x] 5.1 Change the icon for a fit all zoom one
- [x] 5.2 On click find the current total size of the drawing in the main group, then zoom it out so that all the content fit the screen, with a maximum to be defined.
- [ ] 5.3 Add a button to zoom and center to head, with a new icon, and reset the zoom to 1:1 and center to the head (horizontally and vertically)
- [x] 5.4 Make sure that the zoomed version still support drag and drop as well as the move to head function
- [x] 5.5 Add a manual zoom (like ctrl + wheel and num up / down) that enable to manually zoom to different level, should be compatible with the zoom to fit and return to 1:1 button